### PR TITLE
feat: criada entidade portfolio e relacionamento, com RLS de segurança

### DIFF
--- a/supabase/migrations/20260519204025_create_portfolios_table.sql
+++ b/supabase/migrations/20260519204025_create_portfolios_table.sql
@@ -1,0 +1,30 @@
+-- Criação da tabela de portfólios
+CREATE TABLE public.portfolios (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    professional_id UUID REFERENCES public.professionals(id) ON DELETE CASCADE NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    media_url VARCHAR(1024) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- Habilitar RLS, mesmo padrão de segurança, aqueles lá de baixo
+ALTER TABLE public.portfolios ENABLE ROW LEVEL SECURITY;
+
+-- Políticas de segurança
+-- Portfólios são públicos para visualização (necessário para os contratantes verem o trabalho)
+CREATE POLICY "Portfólios visíveis para todos" 
+ON public.portfolios FOR SELECT 
+USING (true);
+
+-- Apenas o profissional dono do portfólio pode alterá-lo
+-- Fazemos um JOIN para verificar se o ID de autenticação bate com o dono do perfil profissional
+CREATE POLICY "Apenas o dono pode atualizar o portfólio" 
+ON public.portfolios FOR UPDATE 
+USING (
+    EXISTS (
+        SELECT 1 FROM public.professionals 
+        WHERE public.professionals.id = public.portfolios.professional_id 
+        AND public.professionals.user_id = auth.uid()
+    )
+);


### PR DESCRIPTION
### Descrição do Pull Request

Este Pull Request implementa a entidade de portfólio (`portfolios`), permitindo que os profissionais armazenem e exibam os seus trabalhos anteriores através de URLs de mídia.

#### Detalhes Arquiteturais e Modificações:
* **Criação da Tabela:** Adicionada a tabela `public.portfolios` com os campos especificados.
* **Integridade Relacional:** O campo `professional_id` foi configurado como Foreign Key apontando para `public.professionals(id)` com `ON DELETE CASCADE`. Isso garante que se um perfil profissional for excluído, todos os seus itens de portfólio serão removidos automaticamente.
* **Segurança de Dados (RLS):** * Permissão de `SELECT`: Pública, para exposição do portfólio.
  * Permissão de `UPDATE`: Restrita através de subquery, garantindo que o `auth.uid()` do usuário autenticado corresponda ao `user_id` atrelado ao `professional_id` do registro.

#### Issues Relacionadas:
* Resolve #7