### PR TITLE
feat: criada entidade professionals conforme issue #4, com correções …

### DIFF
--- a/supabase/migrations/20260522051716_create_professionals_table.sql
+++ b/supabase/migrations/20260522051716_create_professionals_table.sql
@@ -1,0 +1,32 @@
+-- criada tabela de profissionais, com correção dos erros de digitação
+CREATE TABLE public.professionals (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+    bio TEXT,
+    category VARCHAR(255),
+    experience_years INT,
+    city VARCHAR(255),
+    state VARCHAR(255),
+    profile_image VARCHAR(1024), -- URL que virá do Supabase Storage
+    is_verified BOOLEAN DEFAULT false,
+    average_rating DECIMAL(3, 2) DEFAULT 0.00
+);
+
+-- Mais uma vez o RLS (Row Level Security)
+ALTER TABLE public.professionals ENABLE ROW LEVEL SECURITY;
+
+-- Políticas de segurança (Policies)
+-- Qualquer pessoa (clientes e visitantes) pode ver o perfil dos profissionais
+CREATE POLICY "Profissionais visíveis para todos" 
+ON public.professionals FOR SELECT 
+USING (true);
+
+-- Apenas o próprio dono do perfil pode editar os seus dados profissionais
+CREATE POLICY "Apenas o próprio profissional pode atualizar" 
+ON public.professionals FOR UPDATE 
+USING (auth.uid() = user_id);
+
+-- Apenas o próprio usuário pode criar seu registro profissional
+CREATE POLICY "Usuário pode criar o seu registro de profissional" 
+ON public.professionals FOR INSERT 
+WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
### Descrição do Pull Request

Este Pull Request implementa a entidade central de profissionais (`professionals`), que servirá como base para o cadastro de prestadores de serviço, vinculando-os aos seus perfis de autenticação.

#### Detalhes Arquiteturais e Modificações:
* **Criação da Tabela:** Adicionada a tabela `public.professionals`.
* **Correção de Nomenclatura:** Foram aplicadas correções de *typos* identificados na issue original para manter a padronização e qualidade do banco de dados:
  * `EXPIRENCE_YERS` -> `experience_years`
  * `CYTE` -> `city`
  * `IS_VERIFIELD` -> `is_verified`
  * `AVEREGE_RATING` -> `average_rating`
* **Integridade Relacional:** O campo `user_id` foi estabelecido como Foreign Key apontando para `public.profiles(id)` com `ON DELETE CASCADE`.
* **Segurança de Dados (RLS):** * Permissão de `SELECT`: Pública, garantindo que o catálogo de profissionais possa ser listado no frontend.
  * Permissão de `INSERT` e `UPDATE`: Restritas ao proprietário do registro (`auth.uid() = user_id`).

#### Dependência Bloqueante (Aviso aos Revisores):
Este PR deve ser mesclado na branch `dev` antes que possamos iniciar o desenvolvimento das entidades de Portfólio, Serviços e Avaliações, visto que todas essas tabelas exigirão chaves estrangeiras apontando para a tabela `professionals`.

#### Issues Relacionadas:
* Resolve #4