### PR TITLE
Emerson/feature/entidade services

### DIFF
--- a/supabase/migrations/20260519203041_create_contractors_table.sql
+++ b/supabase/migrations/20260519203041_create_contractors_table.sql
@@ -1,0 +1,26 @@
+-- criada a tabela
+CREATE TABLE public.contractors (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID REFERENCES public.profiles(id) ON DELETE CASCADE NOT NULL,
+    company_name VARCHAR(255),
+    document VARCHAR(20) -- Tamanho suficiente para acomodar CPF ou CNPJ formatado
+);
+
+-- Habilitar RLS (Row Level Security) para proteção dos dados conforme requisito
+ALTER TABLE public.contractors ENABLE ROW LEVEL SECURITY;
+
+-- As políticas lá de segurança
+-- Qualquer utilizador autenticado ou público pode ver o perfil da empresa (útil para os profissionais)
+CREATE POLICY "Contratantes visíveis para todos" 
+ON public.contractors FOR SELECT 
+USING (true);
+
+-- Apenas o próprio utilizador (dono do perfil) pode atualizar os dados da sua empresa
+CREATE POLICY "Apenas o próprio contratante pode atualizar" 
+ON public.contractors FOR UPDATE 
+USING (auth.uid() = user_id);
+
+-- Apenas o próprio utilizador pode criar o seu registo como contratante
+CREATE POLICY "Utilizador pode criar o seu registo de contratante" 
+ON public.contractors FOR INSERT 
+WITH CHECK (auth.uid() = user_id);

--- a/supabase/migrations/20260522054225_create_services_table.sql
+++ b/supabase/migrations/20260522054225_create_services_table.sql
@@ -1,0 +1,50 @@
+-- Criação da tabela de serviços
+CREATE TABLE public.services (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    professional_id UUID REFERENCES public.professionals(id) ON DELETE CASCADE NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    category VARCHAR(255)
+);
+
+-- RLS (Row Level Security)
+ALTER TABLE public.services ENABLE ROW LEVEL SECURITY;
+
+-- Políticas de segurança
+-- Catálogo público: Qualquer pessoa pode ver os serviços disponíveis
+CREATE POLICY "Serviços visíveis para todos" 
+ON public.services FOR SELECT 
+USING (true);
+
+-- Inserção: O usuário logado só pode inserir um serviço se o professional_id pertencer a ele
+CREATE POLICY "Profissionais criam os seus próprios serviços" 
+ON public.services FOR INSERT 
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM public.professionals 
+        WHERE public.professionals.id = professional_id 
+        AND public.professionals.user_id = auth.uid()
+    )
+);
+
+-- Edição: O usuário logado só pode atualizar um serviço se for o dono
+CREATE POLICY "Apenas o dono pode atualizar o serviço" 
+ON public.services FOR UPDATE 
+USING (
+    EXISTS (
+        SELECT 1 FROM public.professionals 
+        WHERE public.professionals.id = public.services.professional_id 
+        AND public.professionals.user_id = auth.uid()
+    )
+);
+
+-- Exclusão: O usuário logado só pode deletar o seu próprio serviço
+CREATE POLICY "Apenas o dono pode deletar o serviço" 
+ON public.services FOR DELETE 
+USING (
+    EXISTS (
+        SELECT 1 FROM public.professionals 
+        WHERE public.professionals.id = public.services.professional_id 
+        AND public.professionals.user_id = auth.uid()
+    )
+);


### PR DESCRIPTION
### Descrição do Pull Request

Este Pull Request implementa a entidade de Serviços (`services`), responsável por armazenar o catálogo de ofertas disponíveis na plataforma.

#### Decisão de Arquitetura e Engenharia:
A issue original solicitava os campos `id`, `nome`, `descrição` e `categoria`. Como correção arquitetural proativa, foi adicionada a Foreign Key `professional_id`. Em um modelo relacional, é mandatório vincular o serviço ao seu prestador para evitar registros órfãos e permitir a correta renderização do catálogo por profissional no frontend.

#### Detalhes Arquiteturais e Modificações:
* **Criação da Tabela:** Adicionada a tabela `public.services`.
* **Integridade Relacional:** Inclusão de `professional_id` com diretiva `ON DELETE CASCADE` ligada a `public.professionals(id)`.
* **Segurança de Dados (RLS):** * `SELECT`: Acesso público liberado para listagem de catálogo.
  * `INSERT`, `UPDATE` e `DELETE`: Políticas rigorosas implementadas com *subqueries*, garantindo que apenas o usuário de autenticação correspondente ao dono do perfil profissional possa manipular seus próprios serviços.

#### Dependência (Aviso aos Revisores):
Este PR depende da existência da tabela `professionals` (Issue #4). O merge só deve ser realizado após a Issue #4 estar integrada na branch `dev`.

#### Issues Relacionadas:
* Resolve #2