### PR TITLE
feat: create midia upload system

### DIFF
--- a/supabase/migrations/20260525192739_create_storage_buckets.sql
+++ b/supabase/migrations/20260525192739_create_storage_buckets.sql
@@ -1,0 +1,36 @@
+-- Cria o bucket (tipo o G-drive) que vão ficar os arquivos
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('avatars', 'avatars', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Cria o bucket pras img do portfolio
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('portfolios', 'portfolios', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Regras de segurança e pras fotos de avatar/perfil
+CREATE POLICY "Qualquer pessoa pode visualizar fotos de perfil"
+ON storage.objects FOR SELECT
+USING (bucket_id = 'avatars');
+
+CREATE POLICY "Usuários autenticados podem fazer upload de foto de perfil"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+-- aqui são as regras pra portfolio, mesmo sistema do avatar
+CREATE POLICY "Qualquer pessoa pode ver imagens dos portfólios"
+ON storage.objects FOR SELECT
+USING (bucket_id = 'portfolios');
+
+-- IF user profissional? insere foto
+CREATE POLICY "Apenas profissionais cadastrados podem inserir mídias de portfólio"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+    bucket_id = 'portfolios' 
+    AND EXISTS (
+        SELECT 1 FROM public.professionals 
+        WHERE public.professionals.user_id = auth.uid()
+    )
+);


### PR DESCRIPTION
### Descrição do Pull Request

Este Pull Request implementa a infraestrutura de Armazenamento de Mídia (`storage`), configurando os repositórios de arquivos (buckets) necessários para a plataforma e estabelecendo políticas rígidas de acesso (RLS).

#### Detalhes Arquiteturais e Modificações:
* **Automação de Infraestrutura:** Criação automatizada de dois buckets nativos no ecossistema do Supabase via script de migração:
  * `avatars`: Destinado a armazenar fotos de perfil de usuários (profissionais e contratantes).
  * `portfolios`: Destinado a armazenar mídias comprobatórias de serviços e portfólio dos profissionais.
* **Segurança de Objetos (RLS aplicada ao Storage):**
  * Acesso de leitura (`SELECT`) configurado como público para ambos os buckets, permitindo a renderização imediata das imagens no aplicativo.
  * Upload de avatares restrito a usuários autenticados e isolado pelo ID do próprio usuário.
  * Upload de portfólios protegido por uma cláusula `EXISTS`, validando se o usuário que tenta enviar o arquivo possui um registro ativo na tabela relacional `public.professionals`.

#### Issues Relacionadas:
* Resolve #6